### PR TITLE
Create a single, self-contained, executable

### DIFF
--- a/src/adr.sln
+++ b/src/adr.sln
@@ -1,11 +1,10 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "adr-cli", "adr\adr-cli.csproj", "{A449BAF4-C963-4A14-970B-8912262D78C0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "adr-cli", "adr\adr-cli.csproj", "{A449BAF4-C963-4A14-970B-8912262D78C0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "adr.tests\tests.csproj", "{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tests", "adr.tests\tests.csproj", "{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,33 +15,36 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x64.ActiveCfg = Debug|x64
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x64.Build.0 = Debug|x64
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x86.ActiveCfg = Debug|x86
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x86.Build.0 = Debug|x86
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x86.Build.0 = Debug|Any CPU
 		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x64.ActiveCfg = Release|x64
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x64.Build.0 = Release|x64
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x86.ActiveCfg = Release|x86
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x86.Build.0 = Release|x86
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x64.ActiveCfg = Release|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x64.Build.0 = Release|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x86.Build.0 = Release|Any CPU
 		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x64.ActiveCfg = Debug|x64
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x64.Build.0 = Debug|x64
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x86.ActiveCfg = Debug|x86
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x86.Build.0 = Debug|x86
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x86.Build.0 = Debug|Any CPU
 		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x64.ActiveCfg = Release|x64
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x64.Build.0 = Release|x64
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x86.ActiveCfg = Release|x86
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x86.Build.0 = Release|x86
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x64.Build.0 = Release|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B2DB64EC-6CBA-42F4-9C14-0B4A4C280101}
 	EndGlobalSection
 EndGlobal

--- a/src/adr.tests/tests.csproj
+++ b/src/adr.tests/tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/adr/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/adr/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\netcoreapp3.1\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>True</PublishSingleFile>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishTrimmed>False</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/src/adr/adr-cli.csproj
+++ b/src/adr/adr-cli.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
+    <StartupObject>adr.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />


### PR DESCRIPTION
The original code creates a lot of files that can be put in the PATH of your machine.

However, it's easier for the end-user to just add a single executable. This way the tool can be added to a shared `tool` directory which is already added to the PATH.

The downside, the single executable is ~70MB, because it contains lots of stuff from the .NET Core 3.1 framework as it's a self-contained executable.

The publish profile is for Windows 64-bit operating system.