### PR TITLE
Fix running `init`

### DIFF
--- a/src/adr.sln
+++ b/src/adr.sln
@@ -1,11 +1,10 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "adr-cli", "adr\adr-cli.csproj", "{A449BAF4-C963-4A14-970B-8912262D78C0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "adr-cli", "adr\adr-cli.csproj", "{A449BAF4-C963-4A14-970B-8912262D78C0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "adr.tests\tests.csproj", "{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tests", "adr.tests\tests.csproj", "{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,33 +15,36 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x64.ActiveCfg = Debug|x64
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x64.Build.0 = Debug|x64
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x86.ActiveCfg = Debug|x86
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x86.Build.0 = Debug|x86
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Debug|x86.Build.0 = Debug|Any CPU
 		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x64.ActiveCfg = Release|x64
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x64.Build.0 = Release|x64
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x86.ActiveCfg = Release|x86
-		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x86.Build.0 = Release|x86
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x64.ActiveCfg = Release|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x64.Build.0 = Release|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{A449BAF4-C963-4A14-970B-8912262D78C0}.Release|x86.Build.0 = Release|Any CPU
 		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x64.ActiveCfg = Debug|x64
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x64.Build.0 = Debug|x64
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x86.ActiveCfg = Debug|x86
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x86.Build.0 = Debug|x86
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Debug|x86.Build.0 = Debug|Any CPU
 		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x64.ActiveCfg = Release|x64
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x64.Build.0 = Release|x64
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x86.ActiveCfg = Release|x86
-		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x86.Build.0 = Release|x86
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x64.Build.0 = Release|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1BAB1E6-0927-4893-AD8E-0B328BF66E6E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {13AB0FC3-F939-4E9B-AAC8-6B19AE349F32}
 	EndGlobalSection
 EndGlobal

--- a/src/adr.tests/tests.csproj
+++ b/src/adr.tests/tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/adr/AdrEntry.cs
+++ b/src/adr/AdrEntry.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace adr
 {
-    public class AdrEntry
+    internal class AdrEntry
     {
         private readonly string docFolder;
         
@@ -47,7 +47,56 @@ namespace adr
             fileName = Path.Combine(
                 docFolder,
                 $"{fileNumber.ToString().PadLeft(4, '0')}-{SanitizeFileName(this.Title)}.md");
-            using (var writer = File.CreateText(fileName))
+
+            CreateDocumentsFolderIfNotExists();
+
+            WriteAdrFile(fileNumber);
+        }
+
+        private void WriteAdr()
+        {
+            var fileNumber = Directory.Exists(this.docFolder)
+                ? GetNextFileNumber(this.docFolder)
+                : 1;
+            fileName = Path.Combine(
+                this.docFolder,
+                $"{fileNumber.ToString().PadLeft(4, '0')}-{SanitizeFileName(this.Title)}.md");
+
+            CreateDocumentsFolderIfNotExists();
+
+            WriteInitialAdrFile(fileNumber);
+        }
+
+        private void WriteInitialAdrFile(int fileNumber)
+        {
+            using var writer = File.CreateText(this.fileName);
+            {
+                writer.WriteLine($"# {fileNumber}. {this.Title}");
+                writer.WriteLine();
+                writer.WriteLine(DateTime.Today.ToString("yyyy-MM-dd"));
+                writer.WriteLine();
+                writer.WriteLine("## Status");
+                writer.WriteLine();
+                writer.WriteLine("Accepted");
+                writer.WriteLine();
+                writer.WriteLine("## Context");
+                writer.WriteLine();
+                writer.WriteLine("We need to record the architectural decisions made on this project.");
+                writer.WriteLine();
+                writer.WriteLine("## Decision");
+                writer.WriteLine();
+                writer.WriteLine(
+                    "We will use Architecture Decision Records, as described by Michael Nygard in this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions");
+                writer.WriteLine();
+                writer.WriteLine("## Consequences");
+                writer.WriteLine();
+                writer.WriteLine("See Michael Nygard's article, linked above.");
+            }
+        }
+
+        private void WriteAdrFile(int fileNumber)
+        {
+            using var writer = File.CreateText(fileName);
             {
                 writer.WriteLine($"# {fileNumber}. {this.Title}");
                 writer.WriteLine();
@@ -71,35 +120,11 @@ namespace adr
             }
         }
 
-        private void WriteAdr()
+        private void CreateDocumentsFolderIfNotExists()
         {
-            var fileNumber = Directory.Exists(this.docFolder)
-                ? GetNextFileNumber(this.docFolder)
-                : 1;
-            fileName = Path.Combine(
-                docFolder,
-                $"{fileNumber.ToString().PadLeft(4, '0')}-{SanitizeFileName(this.Title)}.md");
-            using (var writer = File.CreateText(fileName))
+            if (!Directory.Exists(this.docFolder))
             {
-                writer.WriteLine($"# {fileNumber}. {this.Title}");
-                writer.WriteLine();
-                writer.WriteLine(DateTime.Today.ToString("yyyy-MM-dd"));
-                writer.WriteLine();
-                writer.WriteLine("## Status");
-                writer.WriteLine();
-                writer.WriteLine("Accepted");
-                writer.WriteLine();
-                writer.WriteLine("## Context");
-                writer.WriteLine();
-                writer.WriteLine("We need to record the architectural decisions made on this project.");
-                writer.WriteLine();
-                writer.WriteLine("## Decision");
-                writer.WriteLine();
-                writer.WriteLine("We will use Architecture Decision Records, as described by Michael Nygard in this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions");
-                writer.WriteLine();
-                writer.WriteLine("## Consequences");
-                writer.WriteLine();
-                writer.WriteLine("See Michael Nygard's article, linked above.");
+                Directory.CreateDirectory(this.docFolder);
             }
         }
 

--- a/src/adr/AdrSettings.cs
+++ b/src/adr/AdrSettings.cs
@@ -1,10 +1,9 @@
-using System;
-using System.IO;
 using Newtonsoft.Json;
+using System.IO;
 
 namespace adr
 {
-    public class AdrSettings
+    internal class AdrSettings
     {
         private const string DefaultFileName = "adr.config.json";
 
@@ -14,18 +13,7 @@ namespace adr
         {
         }
 
-        public static AdrSettings Current
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    instance = Read(new AdrSettings());
-                }
-
-                return instance;
-            }
-        }
+        public static AdrSettings Current => instance ??= Read(new AdrSettings());
 
         public string DocFolder { get; set; }
 

--- a/src/adr/Program.cs
+++ b/src/adr/Program.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reflection;
-using Microsoft.Extensions.CommandLineUtils;
+﻿using Microsoft.Extensions.CommandLineUtils;
 
 namespace adr
 {

--- a/src/adr/adr-cli.csproj
+++ b/src/adr/adr-cli.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
+    <StartupObject>adr.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />


### PR DESCRIPTION
If you run `adr-cli init` on a folder which doesn't have the `docs\adr` folders, the application crashes.
That's because a file is being writing in this folder, but doesn't exist.

Added a small check to see if the folder exists, if not it will create it.

Updated the project to .NET Core 3.1 as I don't have .NET Core 1.1 installed (anymore) on my machine. Also did the same for #3 in order to create a self-contained application.

Also did some small cleaning up, like removing unused usings, using a new language feature and extracted 2 methods which write the files.